### PR TITLE
Add Skill to allowed_tools for all agents

### DIFF
--- a/agents/code.md
+++ b/agents/code.md
@@ -8,6 +8,7 @@ allowed_tools:
   - "Glob"
   - "Edit"
   - "Write"
+  - "Skill"
   - "Bash(git:*)"
   - "Bash(npm:*)"
   - "Bash(npx:*)"

--- a/agents/plan.md
+++ b/agents/plan.md
@@ -8,6 +8,7 @@ allowed_tools:
   - "Grep"
   - "Glob"
   - "Write"
+  - "Skill"
 ---
 
 # Plan Agent

--- a/agents/review.md
+++ b/agents/review.md
@@ -6,6 +6,7 @@ allowed_tools:
   - "Read"
   - "Grep"
   - "Glob"
+  - "Skill"
   - "Bash(git:*)"
   - "Write"
 ---


### PR DESCRIPTION
## Summary

- Adds `"Skill"` to `allowed_tools` in all three built-in agents (plan, code, review)
- Enables agents to use any Claude Code skills the user has configured in their project via model invocation in `--print` mode

## Context

Claude Code skills (SKILL.md files) work in `--print` mode through model invocation — Claude sees skill descriptions in context and can autonomously invoke them via the `Skill` tool. However, the agents couldn't use them because `Skill` wasn't in their `allowed_tools` list.

## Test plan

- [x] Verified skills load in `--print` mode via model invocation
- [x] Ran end-to-end agent pipeline (plan → code → review) with `Skill` in the tool list
- [x] Existing tests pass (`deno test --allow-read --allow-write` — 68/68)

🤖 Generated with [Claude Code](https://claude.com/claude-code)