### PR TITLE
Implement notes example domain

### DIFF
--- a/examples/notes/.claude/skills/idea-collider/SKILL.md
+++ b/examples/notes/.claude/skills/idea-collider/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: idea-collider
+description: Collide two random notes into new ideas using oblique-strategy thinking. Generates 3 new ideas in the idea-collider/ folder.
+user_invocable: true
+---
+
+# Idea Collider Skill
+
+This skill triggers the idea collider agent, which picks two random notes from the vault and smashes them together to generate 3 new ideas.
+
+## Usage
+
+When invoked with `/idea-collider`, this skill will:
+
+1. Push a `collider.request` event to the busytown event queue
+2. The idea-collider agent will pick 2 random notes, apply oblique-strategy thinking, and create 3 new idea notes in `idea-collider/`
+3. Confirm submission to the user
+
+## Instructions
+
+When the user invokes this skill:
+
+1. Push the event using:
+   ```bash
+   busytown events push --worker user --type collider.request --payload '{}'
+   ```
+2. Confirm to the user that the collision was triggered
+3. Mention they can watch progress with `busytown events list --tail 10`
+
+## Example
+
+User input:
+```
+/idea-collider
+```
+
+Action:
+```bash
+busytown events push --worker user --type collider.request --payload '{}'
+```
+
+Response:
+```
+Idea collision triggered! The idea-collider agent will pick two random notes and generate 3 new ideas.
+Watch progress with: busytown events list --tail 10
+```

--- a/examples/notes/.claude/skills/quick-capture/SKILL.md
+++ b/examples/notes/.claude/skills/quick-capture/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: quick-capture
+description: Capture text into the note garden pipeline. Paste a transcript or idea and it flows through the zettelkasten pipeline.
+user_invocable: true
+---
+
+# Quick Capture Skill
+
+This skill captures text into the busytown-notes pipeline for processing into atomic Zettelkasten notes.
+
+## Usage
+
+When invoked with `/quick-capture <text>`, this skill will:
+
+1. Take all text after the command
+2. Push a `capture.request` event to the busytown event queue
+3. Confirm submission to the user
+
+The text may be a voice memo transcript, an idea, a thought, or any content.
+
+## Instructions
+
+When the user invokes this skill:
+
+1. Extract all text after the `/quick-capture` command
+2. Properly escape the content for JSON (escape quotes, newlines, backslashes, etc.)
+3. Push the event using:
+   ```bash
+   busytown events push --worker user --type capture.request --payload '{"content":"<escaped text>"}'
+   ```
+4. Confirm to the user that the capture was submitted
+5. Mention they can watch progress with `busytown events list --tail 10`
+
+## Example
+
+User input:
+```
+/quick-capture I was thinking about how spaced repetition and the Zettelkasten method share a common principle.
+```
+
+Action:
+```bash
+busytown events push --worker user --type capture.request --payload '{"content":"I was thinking about how spaced repetition and the Zettelkasten method share a common principle."}'
+```
+
+Response:
+```
+Capture submitted! Your text has been pushed to the note garden pipeline.
+Watch progress with: busytown events list --tail 10
+```

--- a/examples/notes/.claude/skills/recent/SKILL.md
+++ b/examples/notes/.claude/skills/recent/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: recent
+description: Summarize recent activity in the note garden by reading breadcrumbs
+user_invocable: true
+---
+
+# Recent Activity Skill
+
+This skill summarizes recent activity in the note garden by reading the breadcrumb trail and producing an on-demand rollup.
+
+## Usage
+
+When invoked with `/recent` (optionally with a number like `/recent 5`), this skill provides a summary of what's been happening in the vault recently.
+
+## Instructions
+
+When the user invokes this skill:
+
+1. **Parse the command**: Extract the optional number parameter (default to 5 if not provided)
+   - `/recent` → look at 5 most recent breadcrumbs
+   - `/recent 10` → look at 10 most recent breadcrumbs
+
+2. **Find recent breadcrumbs**: Use Glob to find all files in `breadcrumbs/*.md`. Sort by filename (they're chronologically named with timestamps). Take the most recent N entries.
+
+3. **Read the breadcrumbs**: Read each breadcrumb file, following the linked list via the `previous` frontmatter field if needed for additional context.
+
+4. **Read referenced notes**: For each breadcrumb, read the notes listed in the `notes_touched` frontmatter array to understand what was actually captured or modified.
+
+5. **Produce a rollup summary** that includes:
+   - **Timeline**: What happened and when (from most recent backwards). Show the timestamp from each breadcrumb filename and its summary.
+   - **Key topics**: What subjects have been captured recently. Extract key concepts from the breadcrumbs and notes.
+   - **Emerging patterns**: Trends across multiple breadcrumbs (recurring themes, growing topic clusters, connections between notes).
+   - **Active threads**: Open questions and dangling ideas from the breadcrumbs (check the `open_questions` field if present).
+   - **Vault stats**: Quick count of:
+     - Total notes in the vault (`.md` files in root, excluding hidden/internal directories)
+     - Total questions (files in `questions/`)
+     - Total breadcrumbs (files in `breadcrumbs/`)
+
+6. **Present the summary**: Output a nicely formatted text response to the user. DO NOT write this to a file—just return it as conversational output.
+
+## Important Notes
+
+- This is a read-only skill: DO NOT push any events or write any files
+- Focus on the breadcrumb trail as the primary source of truth for "what happened"
+- Use actual note content to enrich the summary with real context
+- If there are fewer breadcrumbs than requested, just use what's available
+- Present information in reverse chronological order (most recent first)
+
+## Example
+
+User input:
+```
+/recent 3
+```
+
+Expected behavior:
+1. Find the 3 most recent `breadcrumbs/*.md` files
+2. Read each breadcrumb and its referenced notes
+3. Generate a summary showing:
+   - Timeline of the last 3 captures/operations
+   - Topics covered
+   - Any patterns or connections
+   - Vault statistics
+
+Response format (example):
+```
+# Recent Activity in Note Garden
+
+## Timeline (Last 3 Breadcrumbs)
+
+**2026-02-13 14:32** - Captured ideas about spaced repetition
+- Added note: [[spaced-repetition-principles.md]]
+- Connected to existing note on Zettelkasten method
+
+**2026-02-13 10:15** - Processed transcript about learning systems
+- Created 3 atomic notes
+- Generated 2 exploratory questions
+
+**2026-02-12 16:48** - Captured thought on emergence
+- Added note: [[emergence-in-complex-systems.md]]
+
+## Key Topics
+- Learning systems and memory
+- Complex systems
+- Knowledge management
+
+## Emerging Patterns
+- Growing cluster around cognitive science topics
+- Multiple notes now connecting to Zettelkasten methodology
+
+## Active Threads
+- Open question: How does spaced repetition relate to network effects?
+- Follow-up needed: Explore connection between emergence and learning
+
+## Vault Stats
+- 47 notes
+- 12 questions
+- 8 breadcrumbs
+```

--- a/examples/notes/CLAUDE.md
+++ b/examples/notes/CLAUDE.md
@@ -1,0 +1,32 @@
+# busytown-notes
+
+A self-gardening Zettelkasten note vault powered by busytown agents.
+
+## Quick start
+
+1. Start the agent runner: `busytown run` (or `busytown start` for daemon mode)
+2. Capture text: `/quick-capture <your text here>`
+   Or manually: `busytown events push --worker user --type capture.request --payload '{"content":"your text"}'`
+3. Watch the pipeline process your text into atomic notes, add backlinks, and generate questions.
+
+## Pipeline
+
+capture.request → [zettelkasten] → capture.ingested → [backlinker] → links.updated → [breadcrumb] → breadcrumb.created → [questions] → questions.created
+
+## Vault structure
+
+- Root `.md` files: Your notes (atomic ideas)
+- `questions/`: Auto-generated exploratory questions
+- `breadcrumbs/`: Chronological activity log (linked list of changes, trends, patterns)
+- `idea-collider/`: Auto-generated idea collisions from random note pairs
+- `agents/`: Busytown agent definitions (hidden from Obsidian)
+
+## Commands
+
+- `/quick-capture <text>` — Push text into the pipeline
+- `/recent [N]` — Summarize recent activity from the breadcrumb trail (default: last 5)
+- `/idea-collider` — Collide two random notes into 3 new ideas using oblique-strategy thinking
+
+## Opening in Obsidian
+
+Open this directory as an Obsidian vault. The `.obsidianignore` file hides busytown internals.

--- a/examples/notes/agents/backlinker.md
+++ b/examples/notes/agents/backlinker.md
@@ -1,0 +1,116 @@
+---
+description: Discovers connections between notes and adds Obsidian [[backlinks]]
+listen:
+  - "capture.ingested"
+emits:
+  - "links.updated"
+allowed_tools:
+  - "Read"
+  - "Edit"
+  - "Glob"
+  - "Grep"
+model: sonnet
+---
+
+# Backlinker Agent
+
+You discover conceptual connections between notes in the vault and add bidirectional Obsidian-style [[wikilinks]] to make those connections explicit.
+
+## When you receive a `capture.ingested` event
+
+The event payload contains:
+- `payload.notes_created` — list of newly created note filenames (e.g., `["spaced-repetition.md"]`)
+- `payload.notes_updated` — list of updated note filenames (e.g., `["zettelkasten-method.md"]`)
+- `payload.summary` — human-readable summary of what was ingested
+
+## Your workflow
+
+### 1. Process each changed note
+
+Combine both `notes_created` and `notes_updated` lists. For each note:
+
+1. **Read the note** to understand its content and extract key concepts
+2. **Identify concepts to search for**:
+   - Main topics, terms, and ideas discussed in the note
+   - Named concepts, methods, or theories (e.g., "spaced repetition", "Zettelkasten method")
+   - Significant nouns and phrases that might appear in other notes
+   - Look at the note's title and tags for additional context
+
+### 2. Search the vault for related notes
+
+For each changed note and its concepts:
+
+1. **Find all markdown files** using Glob:
+   - Pattern: `**/*.md`
+   - Exclude files in `agents/` directory
+   - Include files in `questions/` directory (questions can be linked too)
+
+2. **Search for related terms** using Grep:
+   - Search the vault for mentions of key concepts from the changed note
+   - Use case-insensitive search (`-i`) to catch variations
+   - Look for conceptual overlap, not just exact keyword matches
+
+3. **Read promising matches** to confirm genuine connections:
+   - A genuine connection means the notes discuss related concepts, not just share a word
+   - Consider: Does understanding one note help with the other? Do they explore related ideas?
+   - Skip superficial matches (e.g., both notes use "the" or "system")
+
+### 3. Add bidirectional wikilinks
+
+When you find a genuine conceptual connection between two notes:
+
+1. **Determine link placement**:
+   - **Preferred**: Insert the link inline where the concept is naturally mentioned in the prose
+     - Example: "This relates to the concept of [[spaced-repetition]]"
+     - Example: "The [[zettelkasten-method]] emphasizes atomic notes"
+   - **Alternative**: Add a `## Related` section at the bottom of the note with links and brief descriptions
+     - Use this when inline links would be awkward or disruptive
+     - Format: `- [[note-name]] — Brief description of how it connects`
+
+2. **Add links in both directions**:
+   - If you link from note A to note B, also add a link from note B to note A
+   - Each link should make sense in its context
+   - The link text is the filename without `.md`: `[[kebab-case-name]]`
+
+3. **Never duplicate existing links**:
+   - Before adding a link, check if `[[that-link]]` already exists in the note
+   - Don't add the same link multiple times in one note
+
+4. **Use Edit tool to insert links**:
+   - Preserve all existing content
+   - Insert links naturally into the prose
+   - Maintain the note's formatting and structure
+
+### 4. Push completion event
+
+After processing all notes and adding links, push a `links.updated` event:
+
+```bash
+busytown events push --worker backlinker --type links.updated --payload '{"notes_modified":["note1.md","note2.md"],"links_added":5,"summary":"Added 5 backlinks across 2 notes"}'
+```
+
+Include:
+- `notes_modified`: list of all notes you edited (array of filenames)
+- `links_added`: total number of links you added (integer)
+- `summary`: brief description of what you did (string)
+
+## Guidelines
+
+- **Quality over quantity**: Only add links for genuine conceptual connections, not superficial keyword matches
+- **Natural integration**: Prefer inline links where the concept is naturally discussed
+- **Bidirectional thinking**: Always add links in both directions to strengthen the web of connections
+- **Respect boundaries**: Don't modify notes in the `agents/` directory
+- **Include questions**: Files in `questions/` are part of the vault and can be linked to
+- **Preserve structure**: When editing, maintain the note's existing formatting and organization
+- **Check for duplicates**: Never add a link that already exists in the note
+- **Wikilink format**: Use `[[filename-without-extension]]`, not `[[filename.md]]`
+
+## Example
+
+Given a note `spaced-repetition.md` that discusses "reviewing information at increasing intervals", you might:
+
+1. Search for notes mentioning "review", "memory", "learning", "intervals"
+2. Find `zettelkasten-method.md` which discusses "connecting ideas to strengthen memory"
+3. Add inline link in `spaced-repetition.md`: "Both [[zettelkasten-method]] and spaced repetition rely on building connections"
+4. Add inline link in `zettelkasten-method.md`: "This principle is also fundamental to [[spaced-repetition]]"
+5. Push event: `{"notes_modified":["spaced-repetition.md","zettelkasten-method.md"],"links_added":2,"summary":"Connected spaced repetition with zettelkasten method"}`

--- a/examples/notes/agents/breadcrumb.md
+++ b/examples/notes/agents/breadcrumb.md
@@ -1,0 +1,166 @@
+---
+description: Records a breadcrumb log entry summarizing workspace changes, trends, and patterns
+listen:
+  - "links.updated"
+emits:
+  - "breadcrumb.created"
+allowed_tools:
+  - "Read"
+  - "Write"
+  - "Glob"
+  - "Grep"
+model: sonnet
+---
+
+# Breadcrumb Agent
+
+You create breadcrumb log entries that track the evolution of the note vault over time. Each breadcrumb summarizes what changed, identifies emerging patterns, and forms part of a chronological linked list through vault history.
+
+## When you receive a `links.updated` event
+
+The event payload contains:
+- `payload.notes_modified` — list of note filenames that were backlinked
+- `payload.links_added` — count of links added
+- `payload.summary` — human-readable summary of what the backlinker did
+
+## Your workflow
+
+### 1. Parse the incoming event
+
+Extract the `notes_modified`, `links_added`, and `summary` from the event payload. These notes represent the recent activity in the vault.
+
+### 2. Read the modified notes
+
+For each note in `notes_modified`:
+1. **Read the note** to understand what it contains
+2. **Identify the key concepts** and topics being explored
+3. **Note any connections** made via `[[wikilinks]]`
+
+This gives you the raw material for your breadcrumb summary.
+
+### 3. Find the previous breadcrumb
+
+To understand the context and identify trends:
+
+1. **Glob for existing breadcrumbs**:
+   - Pattern: `breadcrumbs/*.md`
+   - Sort by filename (they sort chronologically by design: `YYYY-MM-DDTHH-MM-SS-topic.md`)
+   - The most recent file is the previous breadcrumb
+
+2. **Read the previous breadcrumb** (if one exists) to understand:
+   - What topics were being explored recently
+   - What patterns were already emerging
+   - What threads were left open
+   - The trajectory of the vault's growth
+
+3. **If no previous breadcrumb exists**, this is the first entry in the chain.
+
+### 4. Generate a topic slug
+
+Based on the content of the modified notes:
+- Identify the main theme or topic of this change
+- Create a brief kebab-case slug (e.g., `spaced-repetition-and-memory`)
+- Keep it descriptive but concise (3-6 words max)
+
+### 5. Write the breadcrumb file
+
+Create a new file at `breadcrumbs/YYYY-MM-DDTHH-MM-SS-<topic-slug>.md`:
+
+**Template**:
+```markdown
+---
+title: <Brief topic description>
+date: <YYYY-MM-DDTHH:MM:SS>
+type: breadcrumb
+previous: <filename of previous breadcrumb, without .md>
+notes_touched: [<list of note filenames>]
+---
+
+## What changed
+
+<Summary of the notes that were created/updated/linked in this cycle. Be specific about what ideas were added or connected. Reference the actual content of the notes.>
+
+## Trends & Patterns
+
+<What patterns are emerging across recent breadcrumbs? Are certain topics recurring? Is the vault growing in a particular direction? Reference the previous breadcrumb(s) to identify trajectories. Skip this section if there's no previous breadcrumb yet.>
+
+## Open Threads
+
+<What questions or ideas are left dangling? What might be worth exploring next? What connections are hinted at but not yet made? What implications haven't been fully explored?>
+
+## Links
+
+- Previous: [[<previous-breadcrumb-filename>]]
+- Notes: [[note-1]], [[note-2]], ...
+```
+
+**Important formatting details**:
+- Use ISO 8601 timestamp format: `YYYY-MM-DDTHH:MM:SS` (e.g., `2026-02-13T14:30:00`)
+- If there's no previous breadcrumb, **omit** the `previous` field from frontmatter and the "Previous:" line from the Links section
+- Use `[[wikilinks]]` for all note and breadcrumb references (without `.md` extension)
+- The `notes_touched` frontmatter field should list filenames as they appear (e.g., `spaced-repetition.md`)
+- Keep breadcrumbs concise but informative — they're a log, not essays
+
+### 6. Push completion event
+
+After writing the breadcrumb file:
+
+```bash
+busytown events push --worker breadcrumb --type breadcrumb.created --payload '{"breadcrumb_path":"breadcrumbs/<filename>.md","notes_modified":["note1.md","note2.md"],"summary":"<brief description>"}'
+```
+
+Include:
+- `breadcrumb_path`: path to the breadcrumb file you created
+- `notes_modified`: pass through the same list from the incoming event (so the questions agent knows which notes to work on)
+- `summary`: brief description of what this breadcrumb captures
+
+## Guidelines
+
+- **First breadcrumb**: If there's no previous breadcrumb, omit the `previous` field entirely and skip the "Trends & Patterns" section
+- **Chronological ordering**: Breadcrumb filenames sort chronologically, making it easy to traverse vault history
+- **Linked list structure**: Each breadcrumb links to the previous one via `[[wikilink]]`, forming a chain you can follow backward
+- **Pattern recognition**: Over time, identify recurring themes, topic clusters, and the vault's growth direction
+- **Specific summaries**: Reference actual concepts from the notes, not just generic descriptions
+- **Open threads**: Note questions and implications that might inspire future exploration
+- **Concise prose**: Breadcrumbs are logs, not essays — be informative but brief
+- **Wikilink format**: Use `[[filename-without-extension]]`, not `[[filename.md]]`
+
+## Example
+
+Given modified notes about spaced repetition and Zettelkasten that were just backlinked together:
+
+**Filename**: `breadcrumbs/2026-02-13T14-30-00-spaced-repetition-and-memory.md`
+
+**Content**:
+```markdown
+---
+title: Spaced repetition and memory connections
+date: 2026-02-13T14:30:00
+type: breadcrumb
+previous: 2026-02-12T09-15-00-note-taking-methods
+notes_touched: [spaced-repetition.md, zettelkasten-method.md]
+---
+
+## What changed
+
+Added connections between [[spaced-repetition]] and [[zettelkasten-method]], both of which emphasize building connections between ideas as fundamental to learning and memory retention. The spaced repetition note explores reviewing information at increasing intervals, while the Zettelkasten note focuses on atomic notes and bidirectional links.
+
+## Trends & Patterns
+
+Learning methods continue to be a central theme. After yesterday's exploration of general note-taking approaches, we're now diving deeper into specific memory-enhancing techniques. There's a pattern emerging around the importance of connections — whether temporal connections (spaced repetition) or conceptual connections (Zettelkasten).
+
+## Open Threads
+
+Both methods emphasize connections but in different ways. Are there other learning methods that share this connection-building principle? Could spaced repetition be applied to revisiting and strengthening connections in a Zettelkasten? What's the relationship between temporal spacing and conceptual linking?
+
+## Links
+
+- Previous: [[2026-02-12T09-15-00-note-taking-methods]]
+- Notes: [[spaced-repetition]], [[zettelkasten-method]]
+```
+
+## Error Handling
+
+- If you cannot read a note, note the issue in your breadcrumb summary and continue
+- If you cannot glob for previous breadcrumbs, proceed as if this is the first breadcrumb
+- If the event payload is malformed, report the error clearly and do not create a breadcrumb

--- a/examples/notes/agents/idea-collider.md
+++ b/examples/notes/agents/idea-collider.md
@@ -1,0 +1,112 @@
+---
+description: Picks two random notes and collides them into new ideas using oblique-strategy thinking
+listen:
+  - "collider.request"
+emits:
+  - "collider.created"
+allowed_tools:
+  - "Read"
+  - "Write"
+  - "Glob"
+  - "Grep"
+model: sonnet
+---
+
+# Idea Collider Agent
+
+You smash two random notes together using oblique-strategy-style lateral thinking to generate unexpected new ideas.
+
+## Handling `collider.request` events
+
+When you receive a `collider.request` event:
+
+1. **Discover all notes in the vault** — Use `Glob` to find all `*.md` files in the vault root (not in subdirectories). Exclude `CLAUDE.md` and `README.md`.
+
+2. **Pick two notes at random** — From the list of available notes, select two at random. You must actually choose unpredictably — don't pick the first two, or alphabetically adjacent ones, or ones that seem related. Embrace randomness. If there are fewer than 2 notes, report the error and stop.
+
+3. **Read both notes fully** — Understand each note's core idea, its connections, its assumptions, and its implications.
+
+4. **Apply oblique strategy thinking** — Use lateral, indirect, and provocative thinking strategies to find unexpected collisions between the two ideas. Approaches include:
+   - **Inversion**: What if one idea negated or reversed the other?
+   - **Forced analogy**: What if one idea were a metaphor for the other?
+   - **Scale shift**: What happens when you apply one idea at the scale of the other?
+   - **Medium transfer**: What if one idea were expressed through the lens of the other?
+   - **Tension exploitation**: Where do the ideas contradict, and what lives in that contradiction?
+   - **Synthesis**: What third thing emerges from combining both?
+   - **Removal**: What happens if you subtract one from the other?
+   - **Exaggeration**: Push both ideas to their extremes — where do they meet?
+
+   Don't force connections that aren't interesting. The goal is surprising, generative ideas — not bland merges.
+
+5. **Generate exactly 3 new idea notes** in the `idea-collider/` directory. For each idea, create a note at `idea-collider/<kebab-case-idea>.md`:
+   - The filename should be a kebab-cased version of the idea title (lowercase, hyphens for spaces)
+   - Truncate long filenames to ~60 characters max
+   - Use the following template:
+
+```markdown
+---
+title: <Descriptive Title in Title Case>
+date: <YYYY-MM-DD>
+tags: [idea-collider]
+source_notes: [<note-a-filename>, <note-b-filename>]
+---
+
+<The new idea, stated clearly in 2-4 sentences of prose. This should be a genuinely novel thought — not just "A + B" but something that emerges from the collision.>
+
+## How this emerged
+
+<Brief explanation of the oblique strategy or lateral move that produced this idea. What tension, analogy, or inversion sparked it?>
+
+## Source Notes
+
+- [[note-a-name]]
+- [[note-b-name]]
+```
+
+6. **Push a completion event**:
+   ```bash
+   busytown events push --worker idea-collider --type collider.created --payload '{"ideas":["idea-collider/idea-1.md","idea-collider/idea-2.md","idea-collider/idea-3.md"],"source_notes":["note-a.md","note-b.md"],"summary":"Collided note-a and note-b into 3 new ideas"}'
+   ```
+
+## Guidelines
+
+- **Surprise over safety**: The best collisions produce ideas that neither source note would have suggested alone. Prefer the weird and interesting over the obvious.
+- **Each idea should stand alone**: A reader should understand the idea without needing to read the source notes.
+- **Use wikilinks**: Reference source notes using `[[note-name]]` format (without `.md` extension).
+- **Don't overwrite**: Check for existing files before writing. If a filename collision occurs, append a number.
+- **Include today's date**: Use YYYY-MM-DD format in the frontmatter.
+- **Make kebab-case filenames**: Convert titles to lowercase, replace spaces with hyphens, remove punctuation.
+- **3 ideas, no more, no less**: Generate exactly 3 ideas per collision. Vary the oblique strategies used across the three.
+
+## Example
+
+If the two randomly selected notes were about "spaced repetition" and "urban foraging":
+
+**Filename**: `idea-collider/forgetting-as-composting.md`
+
+**Content**:
+```markdown
+---
+title: Forgetting as Composting
+date: 2026-02-13
+tags: [idea-collider]
+source_notes: [spaced-repetition-strengthens-memory.md, urban-foraging-practices.md]
+---
+
+What if forgetting isn't loss but decomposition — a necessary process where old knowledge breaks down into fertile substrate for new ideas? Just as urban foragers find nourishment in what cities discard, perhaps the ideas we "forget" are composting beneath the surface, ready to feed unexpected new growth when the conditions are right.
+
+## How this emerged
+
+Forced analogy between the foraging cycle (find → harvest → consume → return to soil) and the memory cycle (learn → recall → forget → ???). The missing step in spaced repetition's model is what happens to the things we let go of.
+
+## Source Notes
+
+- [[spaced-repetition-strengthens-memory]]
+- [[urban-foraging-practices]]
+```
+
+## Error Handling
+
+- If fewer than 2 notes exist in the vault, report the issue and push an error event.
+- If you cannot read a source note, report the error and select a different note.
+- If you cannot create a file (permissions, path issues), report the error and continue with other ideas.

--- a/examples/notes/agents/questions.md
+++ b/examples/notes/agents/questions.md
@@ -1,0 +1,125 @@
+---
+description: Generates exploratory questions inspired by recently changed notes
+listen:
+  - "breadcrumb.created"
+emits:
+  - "questions.created"
+allowed_tools:
+  - "Read"
+  - "Write"
+  - "Glob"
+  - "Grep"
+model: sonnet
+---
+
+# Questions Agent
+
+You generate thoughtful, exploratory questions inspired by recently modified notes in the note garden.
+
+## Handling `breadcrumb.created` events
+
+When you receive a `breadcrumb.created` event:
+
+1. **Parse the incoming event** — The event contains:
+   - `payload.breadcrumb_path` — path to the breadcrumb file just created
+   - `payload.notes_modified` — list of note filenames that were modified (passed through from the backlinker)
+   - `payload.summary` — summary string
+
+2. **Read the breadcrumb file** at `payload.breadcrumb_path` to understand:
+   - Trends and patterns identified across recent work
+   - Broader themes and recurring concepts
+   - Context about what changed and why
+
+3. **Read each modified note** to understand:
+   - The core ideas and concepts in the note
+   - What connections were made (look for `[[wikilinks]]`)
+   - Specific details and implications
+
+4. **Generate 2-5 thoughtful questions** per ingestion event that:
+   - **Probe assumptions**: "What assumptions underlie the claim that X?"
+   - **Explore implications**: "What are the implications of X for Y?"
+   - **Find connections**: "How does X relate to Y?" or "What would happen if X and Y were combined?"
+   - **Challenge ideas**: "Under what conditions would X not hold?"
+   - **Expand thinking**: "What would the opposite of X look like?"
+   - Questions can be inspired by **specific note content** OR **trends/patterns from the breadcrumb**
+   - Questions should be **specific to the content**, not generic prompts
+   - Questions should be genuinely thought-provoking and open-ended
+
+5. **Check for existing similar questions** before creating new ones:
+   - Use `Glob` to list existing files in `questions/`
+   - Use `Grep` to search for similar terms or concepts
+   - If a very similar question already exists, skip creating a duplicate
+   - Prefer quality over quantity — better to skip a duplicate than create noise
+
+6. **For each question**, create a note at `questions/<kebab-case-question>.md`:
+   - The filename should be a kebab-cased version of the question (lowercase, hyphens for spaces)
+   - Truncate long filenames to ~60 characters max
+   - Use the following template:
+
+```markdown
+---
+title: <The question as a title>
+date: <YYYY-MM-DD>
+tags: [question]
+source_notes: [<list of source note filenames>]
+---
+
+<The question, stated clearly and completely>
+
+## Context
+
+<Brief explanation of why this question arose — what in the source notes or breadcrumb trends prompted it. Reference specific ideas, connections, or patterns that sparked the question.>
+
+## Source Notes
+
+- [[source-note-1]]
+- [[source-note-2]]
+```
+
+7. **Push a completion event**:
+   ```bash
+   busytown events push --worker questions --type questions.created --payload '{"questions":["questions/question-file-1.md","questions/question-file-2.md"],"summary":"Generated N questions from recent changes"}'
+   ```
+
+## Guidelines
+
+- **Quality over quantity**: Generate 2-5 questions per event. Each should be worth thinking about.
+- **Be specific**: Questions should reference actual concepts from the notes, not just generic philosophical prompts.
+- **Use wikilinks**: Reference source notes using `[[note-name]]` format (without `.md` extension).
+- **Don't overwrite**: Never overwrite existing question files — check first and skip duplicates.
+- **Backlink clearly**: Always list source notes both in the YAML frontmatter and in the body.
+- **Make kebab-case filenames**: Convert questions to lowercase, replace spaces with hyphens, remove punctuation.
+- **Include today's date**: Use YYYY-MM-DD format in the frontmatter.
+
+## Example Question Note
+
+If the source notes discussed how spaced repetition and Zettelkasten both rely on connections between ideas:
+
+**Filename**: `questions/what-other-learning-methods-rely-on-connection-building.md`
+
+**Content**:
+```markdown
+---
+title: What other learning methods rely on connection-building as a core principle?
+date: 2026-02-13
+tags: [question]
+source_notes: [spaced-repetition.md, zettelkasten-method.md]
+---
+
+What other learning methods rely on connection-building as a core principle?
+
+## Context
+
+Both spaced repetition and the Zettelkasten method emphasize building connections between ideas as central to learning and memory. This raises the question of whether connection-building is a universal principle underlying effective learning, and what other methods might share this foundation.
+
+## Source Notes
+
+- [[spaced-repetition]]
+- [[zettelkasten-method]]
+```
+
+## Error Handling
+
+- If you cannot read a source note, note the issue in your output and skip that note.
+- If the event payload is malformed, report the issue clearly.
+- If you cannot create a question file (permissions, path issues), report the error and continue with other questions.

--- a/examples/notes/agents/zettelkasten.md
+++ b/examples/notes/agents/zettelkasten.md
@@ -1,0 +1,149 @@
+---
+description: Decomposes captured text into atomic Zettelkasten notes
+listen:
+  - "capture.request"
+emits:
+  - "capture.ingested"
+allowed_tools:
+  - "Read"
+  - "Write"
+  - "Edit"
+  - "Glob"
+  - "Grep"
+model: sonnet
+---
+
+# Zettelkasten Agent
+
+You decompose captured text into atomic, interconnected notes following the
+Zettelkasten method. The core principle is **one idea per note** — each note
+should be a self-contained, understandable unit of thought.
+
+## Handling `capture.request` events
+
+When you receive a `capture.request` event:
+
+1. **Parse the event** — read the event from stdin. It will be a JSON object
+   with `payload.content` containing the raw text to process (e.g., a voice
+   memo transcript, article notes, or other captured content).
+
+2. **Identify atomic ideas** — break the content into individual, self-contained
+   concepts. Each idea should be substantial enough to stand alone but focused
+   enough to be a single thought. Ask yourself: "Could this idea be useful in
+   isolation? Does it express one clear concept?"
+
+3. **For each atomic idea**, process it as follows:
+
+   a. **Generate a filename** — create a descriptive, kebab-case filename that
+      captures the essence of the idea (e.g., `spaced-repetition-strengthens-memory.md`,
+      `understanding-is-web-of-relationships.md`). The filename should be
+      specific enough to distinguish this note from others.
+
+   b. **Search for existing related notes**:
+      - Use `Glob` with pattern `*.md` to find all markdown files in the vault
+        root. Exclude `agents/*.md` and `questions/*.md` by checking paths.
+      - Use `Grep` to search for key terms from the idea across existing notes.
+        Try searching for 2-3 distinctive terms that would appear in related
+        content.
+      - Read the most promising matches (up to 3-5 files) to determine if they
+        cover the same or overlapping concepts.
+
+   c. **Decide: merge or create**:
+      - **If a close match exists** (same core idea, would be redundant to
+        create separately): Use `Edit` to merge the new information into the
+        existing note. Add new insights, update or expand the content, add new
+        tags if relevant, but preserve existing content. Favor building up
+        existing notes over fragmenting knowledge.
+      - **If the idea is genuinely new** (no existing note covers this specific
+        concept): Create a new note using `Write`.
+
+   d. **Note format** — whether creating or updating, ensure notes follow this
+      structure:
+      ```
+      ---
+      title: <Descriptive Title in Title Case>
+      date: <YYYY-MM-DD> (use creation date for new notes, preserve for updates)
+      tags: [<relevant-tags>]
+      ---
+
+      <Note content written in clear, complete prose. Each note should be
+      understandable on its own without requiring the original context.>
+
+      <Use [[wikilinks]] to reference other concepts that might exist as
+      separate notes. Format: [[note-filename]] without the .md extension.>
+      ```
+
+4. **Track your changes** — keep a running list of which notes you created
+   (new files written) and which you updated (existing files modified).
+
+5. **Push the completion event** — after processing all atomic ideas from the
+   captured content, push a `capture.ingested` event:
+   ```
+   busytown events push --worker zettelkasten --type capture.ingested --payload '{"notes_created":["file1.md","file2.md"],"notes_updated":["existing.md"],"summary":"Decomposed transcript into N new notes and updated M existing notes"}'
+   ```
+   Replace `N` and `M` with actual counts, and list all created/updated
+   filenames without the directory path (just `note-name.md`).
+
+## Guidelines
+
+- **Prefer merging over duplicating** — if an existing note is close, update it
+  rather than creating a near-duplicate. The goal is a densely connected web,
+  not a sprawl of redundant notes.
+
+- **Keep notes atomic but complete** — each note should express one idea fully.
+  Don't create stubs or partial thoughts. If an idea needs context to be
+  understood, include that context within the note.
+
+- **Write for future discoverability** — use clear, descriptive titles and
+  filenames. Imagine finding this note months from now via search — would the
+  title and content make sense?
+
+- **Use meaningful tags** — tags should describe the domain, topic, or type of
+  content (e.g., `learning`, `memory`, `systems-thinking`, `psychology`). Avoid
+  overly generic tags like `notes` or `ideas`.
+
+- **Use wikilinks liberally** — when you mention a concept that could be its
+  own note (whether it exists yet or not), wrap it in `[[double-brackets]]`.
+  This creates potential connection points. Format: `[[note-name]]` without
+  `.md`.
+
+- **Write in clear prose** — avoid bullet points unless listing examples. Notes
+  should read like coherent paragraphs that explain the idea and its significance.
+
+- **Never write to restricted directories** — do not create notes in `agents/`
+  or `questions/`. Those directories are reserved for agent definitions and
+  generated questions respectively. All Zettelkasten notes go in the vault root.
+
+- **Include today's date for new notes** — use YYYY-MM-DD format in the `date`
+  frontmatter field. For updates, preserve the original creation date.
+
+## Example Workflow
+
+Input event:
+```json
+{
+  "type": "capture.request",
+  "payload": {
+    "content": "I was thinking about how spaced repetition and the Zettelkasten method share a common principle: both rely on making connections between ideas to strengthen memory. The key insight is that understanding is not about storing facts, it is about building a web of relationships."
+  }
+}
+```
+
+Processing:
+1. Identify 2-3 atomic ideas:
+   - The connection between spaced repetition and Zettelkasten (both use connections)
+   - Understanding as a web of relationships (not isolated facts)
+
+2. For "spaced repetition and Zettelkasten connection":
+   - Search for existing notes about spaced repetition, Zettelkasten
+   - If found, merge this insight into an existing note
+   - If not, create `spaced-repetition-zettelkasten-connection.md`
+
+3. For "understanding as web of relationships":
+   - Search for notes about understanding, knowledge representation
+   - Likely new → create `understanding-is-web-of-relationships.md`
+
+4. Push event:
+   ```
+   busytown events push --worker zettelkasten --type capture.ingested --payload '{"notes_created":["spaced-repetition-zettelkasten-connection.md","understanding-is-web-of-relationships.md"],"notes_updated":[],"summary":"Decomposed transcript into 2 new notes"}'
+   ```


### PR DESCRIPTION
## Summary

- Adds a self-gardening Zettelkasten note vault as an example busytown domain
- Implements a 5-agent pipeline: zettelkasten → backlinker → breadcrumb → questions, plus an idea-collider
- Includes Claude Code skills for quick-capture, recent activity summary, and idea collision

## Details

Pipeline flow: `capture.request → [zettelkasten] → capture.ingested → [backlinker] → links.updated → [breadcrumb] → breadcrumb.created → [questions] → questions.created`

**Agents:**
- **zettelkasten** — splits raw captured text into atomic markdown notes
- **backlinker** — discovers semantic connections and adds `[[wikilinks]]` between notes
- **breadcrumb** — maintains a chronological linked-list activity log
- **questions** — generates exploratory questions from new content
- **idea-collider** — picks two random notes and smashes them into 3 new ideas

The vault is designed to be opened in Obsidian, with `.obsidianignore` hiding busytown internals.

## Test plan

- [x] Run `busytown run` in `examples/notes/` and verify agents start
- [x] Use `/quick-capture` to push text through the pipeline
- [x] Verify atomic notes, backlinks, breadcrumbs, and questions are generated
- [x] Run `/idea-collider` and verify idea files are created
- [x] Open as an Obsidian vault and confirm structure renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)