### PR TITLE
Namespace system events under sys.*

### DIFF
--- a/.claude/skills/create-agent/SKILL.md
+++ b/.claude/skills/create-agent/SKILL.md
@@ -190,12 +190,10 @@ first-claim-wins — only one worker can claim each event.
 
 ### Workflow
 
-1. **Claim events** — use `event-queue claim` to atomically take ownership of an
+1. **Claim events** — use `busytown events claim --worker <id:string> --event <id:string>` to atomically take ownership of an
    event
 2. **Handle claim failures** — if the claim response shows `claimed:false`,
    another worker already claimed it; move on
-3. **Listen for claim events** — subscribe to `claim.created` to react to new
-   claims
 
 ### Example Agent Using Claims
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ Event types use dot-separated namespaces: `entity.action`. Examples:
 - `code.review`
 - `review.created`
 - `file.create`, `file.modify`, `file.delete`, `file.rename`
-- `claim.created`, `cursor.create`
+- `sys.claim.created`, `sys.cursor.create`
 
 ### Core operations
 
@@ -89,7 +89,7 @@ cursor. For new workers, creates a cursor at the current tail so they only see
 future events (play-from-now semantics).
 
 **claimEvent(db, workerId, eventId)** — Uses `INSERT OR IGNORE` on the claims
-primary key. Only the first caller wins. Pushes a `claim.created` event on
+primary key. Only the first caller wins. Pushes a `sys.claim.created` event on
 success.
 
 ### Delivery guarantees

--- a/lib/event-queue.test.ts
+++ b/lib/event-queue.test.ts
@@ -386,25 +386,25 @@ Deno.test("claimEvent - same worker claiming twice succeeds", () => {
   db.close();
 });
 
-Deno.test("claimEvent - emits claim.created event on success", () => {
+Deno.test("claimEvent - emits sys.claim.created event on success", () => {
   const db = freshDb();
   const { id: eventId } = pushEvent(db, "w1", "task");
   claimEvent(db, "claimer1", eventId);
 
-  const events = getEventsSince(db, { filterType: "claim.created" });
+  const events = getEventsSince(db, { filterType: "sys.claim.created" });
   assertEquals(events.length, 1);
   assertEquals((events[0].payload as { event_id: number }).event_id, eventId);
   assertEquals(events[0].worker_id, "claimer1");
   db.close();
 });
 
-Deno.test("claimEvent - does not emit claim.created on failure", () => {
+Deno.test("claimEvent - does not emit sys.claim.created on failure", () => {
   const db = freshDb();
   const { id: eventId } = pushEvent(db, "w1", "task");
   claimEvent(db, "claimer1", eventId);
   claimEvent(db, "claimer2", eventId);
 
-  const events = getEventsSince(db, { filterType: "claim.created" });
+  const events = getEventsSince(db, { filterType: "sys.claim.created" });
   assertEquals(events.length, 1); // only the first claim emitted an event
   db.close();
 });
@@ -477,19 +477,19 @@ Deno.test("getEventsSince - tail with filterType returns last N of that type", (
 
 // --- getOrCreateCursor ---
 
-Deno.test("getOrCreateCursor - returns cursor.create event ID for new worker", () => {
+Deno.test("getOrCreateCursor - returns sys.cursor.create event ID for new worker", () => {
   const db = freshDb();
   const since = getOrCreateCursor(db, "new-agent");
   assertEquals(since > 0, true);
   db.close();
 });
 
-Deno.test("getOrCreateCursor - pushes a cursor.create event for new worker", () => {
+Deno.test("getOrCreateCursor - pushes a sys.cursor.create event for new worker", () => {
   const db = freshDb();
   getOrCreateCursor(db, "new-agent");
-  const events = getEventsSince(db, { filterType: "cursor.create" });
+  const events = getEventsSince(db, { filterType: "sys.cursor.create" });
   assertEquals(events.length, 1);
-  assertEquals(events[0].worker_id, "runner");
+  assertEquals(events[0].worker_id, "new-agent");
   assertEquals(
     (events[0].payload as { agent_id: string }).agent_id,
     "new-agent",
@@ -502,7 +502,7 @@ Deno.test("getOrCreateCursor - returns existing cursor value without pushing eve
   updateCursor(db, "existing-agent", 42);
   const since = getOrCreateCursor(db, "existing-agent");
   assertEquals(since, 42);
-  const events = getEventsSince(db, { filterType: "cursor.create" });
+  const events = getEventsSince(db, { filterType: "sys.cursor.create" });
   assertEquals(events.length, 0);
   db.close();
 });

--- a/lib/event-queue.ts
+++ b/lib/event-queue.ts
@@ -277,7 +277,7 @@ export const updateCursor = (
  * Gets or creates a cursor for a worker.
  *
  * If the worker already has a cursor, returns its current position.
- * Otherwise, pushes a `cursor.create` event, sets the cursor to that
+ * Otherwise, pushes a `sys.cursor.create` event, sets the cursor to that
  * event's ID, and returns it — so the new worker starts from the current
  * tail rather than replaying all history.
  *
@@ -294,7 +294,7 @@ export const getOrCreateCursor = (
       "SELECT since FROM worker_cursors WHERE worker_id = ?",
     ).get(workerId) as CursorRow | undefined;
     if (existing) return existing.since;
-    const event = pushEvent(db, "runner", "cursor.create", {
+    const event = pushEvent(db, workerId, "sys.cursor.create", {
       agent_id: workerId,
     });
     updateCursor(db, workerId, event.id);
@@ -306,7 +306,7 @@ export const getOrCreateCursor = (
  * Claims an event for a worker (first-claim-wins).
  *
  * Uses INSERT OR IGNORE with the PRIMARY KEY constraint to ensure only the
- * first worker to claim an event succeeds. Emits a `claim.created` event on success.
+ * first worker to claim an event succeeds. Emits a `sys.claim.created` event on success.
  *
  * @param db - Database connection
  * @param workerId - Worker ID attempting the claim
@@ -327,7 +327,7 @@ export const claimEvent = (
     const check = db.prepare("SELECT worker_id FROM claims WHERE event_id = ?");
     const row = check.get(eventId) as ClaimWorkerRow | undefined;
     if (row && row.worker_id === workerId) {
-      pushEvent(db, workerId, "claim.created", { event_id: eventId });
+      pushEvent(db, workerId, "sys.claim.created", { event_id: eventId });
       return true;
     }
     return false;

--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -96,7 +96,7 @@ export const createSystem = (
     logger.debug("Effect start", { workerId: worker.id });
 
     if (!worker.hidden) {
-      pushEvent(db, worker.id, "worker.effect.start", { eventId: event.id });
+      pushEvent(db, worker.id, "sys.worker.start", { eventId: event.id });
     }
 
     // Get promise for eventual result of effect and track it.
@@ -115,7 +115,7 @@ export const createSystem = (
         error: `${res.error}`,
       });
       if (!worker.hidden) {
-        pushEvent(db, worker.id, "worker.effect.error", {
+        pushEvent(db, worker.id, "sys.worker.error", {
           eventId: event.id,
           error: `${res.error}`,
         });
@@ -126,7 +126,7 @@ export const createSystem = (
         eventId: event.id,
       });
       if (!worker.hidden) {
-        pushEvent(db, worker.id, "worker.effect.finish", {
+        pushEvent(db, worker.id, "sys.worker.finish", {
           eventId: event.id,
         });
       }


### PR DESCRIPTION
`sys` events associated with a worker are authored by that worker. This means that the worker will automatically ignore their own sys events by default, breaking any accidental infinite loops (see ignore_self flag in #57)

Progress toward #46 and the synthesis described in https://github.com/gordonbrander/busytown/issues/46#issuecomment-3901283911