### PR TITLE
Change cursor.claim.created to cursor.claim.create

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ Event types use dot-separated namespaces: `entity.action`. Examples:
 - `code.review`
 - `review.created`
 - `file.create`, `file.modify`, `file.delete`, `file.rename`
-- `sys.claim.created`, `sys.cursor.create`
+- `sys.claim.create`, `sys.cursor.create`
 
 ### Core operations
 
@@ -89,7 +89,7 @@ cursor. For new workers, creates a cursor at the current tail so they only see
 future events (play-from-now semantics).
 
 **claimEvent(db, workerId, eventId)** — Uses `INSERT OR IGNORE` on the claims
-primary key. Only the first caller wins. Pushes a `sys.claim.created` event on
+primary key. Only the first caller wins. Pushes a `sys.claim.create` event on
 success.
 
 ### Delivery guarantees

--- a/lib/event-queue.test.ts
+++ b/lib/event-queue.test.ts
@@ -386,25 +386,25 @@ Deno.test("claimEvent - same worker claiming twice succeeds", () => {
   db.close();
 });
 
-Deno.test("claimEvent - emits sys.claim.created event on success", () => {
+Deno.test("claimEvent - emits sys.claim.create event on success", () => {
   const db = freshDb();
   const { id: eventId } = pushEvent(db, "w1", "task");
   claimEvent(db, "claimer1", eventId);
 
-  const events = getEventsSince(db, { filterType: "sys.claim.created" });
+  const events = getEventsSince(db, { filterType: "sys.claim.create" });
   assertEquals(events.length, 1);
   assertEquals((events[0].payload as { event_id: number }).event_id, eventId);
   assertEquals(events[0].worker_id, "claimer1");
   db.close();
 });
 
-Deno.test("claimEvent - does not emit sys.claim.created on failure", () => {
+Deno.test("claimEvent - does not emit sys.claim.create on failure", () => {
   const db = freshDb();
   const { id: eventId } = pushEvent(db, "w1", "task");
   claimEvent(db, "claimer1", eventId);
   claimEvent(db, "claimer2", eventId);
 
-  const events = getEventsSince(db, { filterType: "sys.claim.created" });
+  const events = getEventsSince(db, { filterType: "sys.claim.create" });
   assertEquals(events.length, 1); // only the first claim emitted an event
   db.close();
 });

--- a/lib/event-queue.ts
+++ b/lib/event-queue.ts
@@ -306,7 +306,7 @@ export const getOrCreateCursor = (
  * Claims an event for a worker (first-claim-wins).
  *
  * Uses INSERT OR IGNORE with the PRIMARY KEY constraint to ensure only the
- * first worker to claim an event succeeds. Emits a `sys.claim.created` event on success.
+ * first worker to claim an event succeeds. Emits a `sys.claim.create` event on success.
  *
  * @param db - Database connection
  * @param workerId - Worker ID attempting the claim
@@ -327,7 +327,7 @@ export const claimEvent = (
     const check = db.prepare("SELECT worker_id FROM claims WHERE event_id = ?");
     const row = check.get(eventId) as ClaimWorkerRow | undefined;
     if (row && row.worker_id === workerId) {
-      pushEvent(db, workerId, "sys.claim.created", { event_id: eventId });
+      pushEvent(db, workerId, "sys.claim.create", { event_id: eventId });
       return true;
     }
     return false;


### PR DESCRIPTION
The event is created transactionally along with the claim, so we should use the present tense.