### PR TITLE
Fix agent event instructions for ralph loop

### DIFF
--- a/agents/code.md
+++ b/agents/code.md
@@ -1,5 +1,6 @@
 ---
 description: Implements code changes by following plans written by the plan agent
+model: "sonnet"
 listen:
   - "plan.created"
 emits:
@@ -35,9 +36,9 @@ When you receive a `plan.created` event:
    - Run any build or type-check commands mentioned in the plan's verification
      section.
 4. Track which files you created or modified.
-5. Push a `code.review` event when done:
+5. When finished, push a `code.review` event with payload
    ```
-   {"type":"code.review","payload":{"plan_path":"plans/...","files_changed":["src/foo.ts","src/bar.ts"],"summary":"Brief description of what was implemented"}}
+   {"plan_path":"plans/...","files_changed":["src/foo.ts","src/bar.ts"],"summary":"Brief description of what was implemented"}
    ```
 
 ## Guidelines

--- a/agents/plan.md
+++ b/agents/plan.md
@@ -1,5 +1,6 @@
 ---
 description: Explores the codebase and writes implementation plans as markdown files
+model: "opus"
 listen:
   - "plan.request"
   - "review.created"
@@ -36,9 +37,9 @@ When you receive a `plan.request` event:
    - **Steps**: Numbered, actionable implementation steps with specific file
      paths and code changes
    - **Verification**: How to confirm the implementation is correct
-5. Push a `plan.created` event:
+5. Push a `plan.created` event with the payload:
    ```
-   {"type":"plan.created","payload":{"plan_path":"plans/<name>.md"}}
+   {"plan_path":"plans/<name>.md"}
    ```
 
 ## Handling `review.created` events
@@ -46,9 +47,9 @@ When you receive a `plan.request` event:
 When you receive a `review.created` event:
 
 1. Read the `payload.verdict` field:
-   - If `"approve"`: push a `plan.complete` event and stop.
+   - If `"approve"`: push a `plan.complete` event and stop. Payload:
      ```
-     {"type":"plan.complete","payload":{"plan_path":"plans/..."}}
+     {"plan_path":"plans/..."}
      ```
    - If `"revise"`: continue to step 2.
 2. Read the review file at `payload.review_path` for detailed feedback. Also

--- a/agents/review.md
+++ b/agents/review.md
@@ -1,5 +1,6 @@
 ---
 description: Reviews code changes for correctness, type safety, and style
+model: "opus"
 listen:
   - "code.review"
 emits:
@@ -42,9 +43,9 @@ When you receive a `code.review` event:
    - **Issues**: Detailed list of issues found (if any), with file paths and
      line numbers
    - **Files reviewed**: List of files that were reviewed
-7. Push a `review.created` event:
+7. Push a `review.created` event with payload:
    ```
-   {"type":"review.created","payload":{"plan_path":"plans/...","review_path":"reviews/...","verdict":"approve|revise","issues":["issue 1","issue 2"],"summary":"Brief review summary"}}
+   {"plan_path":"plans/...","review_path":"reviews/...","verdict":"approve|revise","issues":["issue 1","issue 2"],"summary":"Brief review summary"}
    ```
 
 ## Guidelines


### PR DESCRIPTION
The event push API changed in #26. This PR updates the agent instructions for the three-phase Ralph coding loop.